### PR TITLE
Adjpval sorting hotfix

### DIFF
--- a/web-app/HeimScripts/heatmap/run.R
+++ b/web-app/HeimScripts/heatmap/run.R
@@ -31,7 +31,7 @@ main <- function(max_rows = 100, sorting = "nodes", ranking = "coef") {
   # otherwise we get a dataframe
   patientIDs  <- unique(fields["PATIENTID"])[,1]
 
-  significanceValues <- unique(fields["SIGNIFICANCE"])[,1]
+  significanceValues <- df["SIGNIFICANCE"][,1]
   features <- unique(extraFields["FEATURE"])[,1]
   jsn <- list(
     "fields"             = fields,

--- a/web-app/HeimScripts/heatmap/run.R
+++ b/web-app/HeimScripts/heatmap/run.R
@@ -468,8 +468,8 @@ dendrogramToJSON <- function(d) {
 addClusteringOutput <- function(jsn, measurements_arg) {
   # we need to discard rows and columns without at least two values
   # determine rows without two non-NAs
-  thresholdRows <- ceiling(ncol(measurements_arg) / 2 ) + 1  #  Half of the lentgh +1 has to be filled otherwise
-  thresholdCols <- ceiling(nrow(measurements_arg) / 2 ) + 1  #  there might not be enough overlap for clustering
+  thresholdRows <- floor(ncol(measurements_arg) / 2 ) + 1  #  Half of the lentgh +1 has to be filled otherwise
+  thresholdCols <- floor(nrow(measurements_arg) / 2 ) + 1  #  there might not be enough overlap for clustering
   logicalSelection <- apply(measurements_arg, 1, function(row) length(which(!is.na(row))) >= thresholdRows)
   measurements_rows <- measurements_arg[logicalSelection, ]
   # and for columns

--- a/web-app/js/smartR/d3Heatmap.js
+++ b/web-app/js/smartR/d3Heatmap.js
@@ -457,13 +457,16 @@ SmartRHeatmap = (function(){
             var bar = barItems.selectAll('.bar')
                 .data(significanceIndexMap, function(d) { return d.idx; });
 
+            var _MINIMAL_WIDTH = 10;  // This value will be added to the scaled width. So that it is always >0 (visible)
+            var _BAR_OFFSET    = 20;  // Distance between significance bar and the heatmap.
+                                      // Visible offset will be effectively _BAR_OFFSET - _MINIMAL_WIDTH
             bar
                 .enter()
                 .append('rect')
                 .attr('class', function(d) { return 'bar idx-' + d.idx ; })
-                .attr("width", function(d) { return histogramScale( Math.abs( d.significance) ); })
+                .attr("width", function(d) { return histogramScale( Math.abs( d.significance) ) + _MINIMAL_WIDTH; })
                 .attr("height", gridFieldHeight)
-                .attr("x", function(d) { return - histogramScale( Math.abs( d.significance)) - 10; })
+                .attr("x", function(d) { return - histogramScale( Math.abs( d.significance)) - _BAR_OFFSET; })
                 .attr("y", function(d) { return gridFieldHeight * d.idx; })
                 .style('fill', function(d) { return d.significance > 0 ? 'steelblue' : '#990000';})
                 .on("mouseover", function(d) {
@@ -488,8 +491,8 @@ SmartRHeatmap = (function(){
                 .transition()
                 .duration(animationDuration)
                 .attr("height", gridFieldHeight)
-                .attr("width", function(d) { return histogramScale(Math.abs( d.significance) ); })
-                .attr("x", function(d) { return - histogramScale( Math.abs( d.significance) ) - 10; })
+                .attr("width", function(d) { return histogramScale(Math.abs( d.significance)) + _MINIMAL_WIDTH ; })
+                .attr("x", function(d) { return - histogramScale( Math.abs( d.significance) ) - _BAR_OFFSET; })
                 .attr("y", function(d) { return gridFieldHeight * d.idx; })
                 .style('fill', function(d) {return d.significance > 0 ? 'steelblue' : '#990000';
                 });


### PR DESCRIPTION
Three things:
- Fixing the case where rows collapse during sorting. This was caused by significance array in JSON being shorter than the probeid vector. Because of unnecessary unique() applied to it.
- Added minimal width to the significance bar so that it does not appear to be missing for the first row.  
- (unrelated but minor change) replaced ceiling with floor division when calculating clustering threshold so that it is not unnecessarily strict but exactly at length /2 +1 
